### PR TITLE
Check whether DoNotTrack is set and don't call statcounter.com in that case

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,19 +44,20 @@
     8values is licensed under the MIT License, which permits "without restriction" the rights to "use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 	copies of the Software". LeftValues is thus able to legally modify the original 8values without infringing on any copyright. LeftValues also utilizes the same license.</p>
 
-<!-- Default Statcounter code for LeftValues http://leftvalues.github.io -->
+<!-- Privacy respecting Statcounter code for LeftValues http://leftvalues.github.io -->
 <script type="text/javascript">
 var sc_project=12079783; 
 var sc_invisible=1; 
 var sc_security="fa5443fa"; 
-var sc_https=1; 
+var sc_https=1;
+
+if(navigator.doNotTrack != 1) {
+var statcounterscript=document.createElement('script');
+statcounterscript.setAttribute("type","text/javascript");
+statcounterscript.setAttribute("src", "https://www.statcounter.com/counter/counter.js");
+document.getElementsByTagName("body")[0].appendChild(statcounterscript);
+}
 </script>
-<script type="text/javascript"
-src="https://www.statcounter.com/counter/counter.js" async></script>
-<noscript><div class="statcounter"><a title="Web Analytics"
-href="https://statcounter.com/" target="_blank"><img class="statcounter"
-src="https://c.statcounter.com/12079783/0/fa5443fa/1/" alt="Web
-Analytics"></a></div></noscript>
 <!-- End of Statcounter Code -->
 
 <!-- This is the script for the page itself -->

--- a/instructions.html
+++ b/instructions.html
@@ -16,19 +16,19 @@
 <button data-i18n="inst-gotit" class="button" onclick="location.href='quiz.html';" style="background-color: #2196f3;">Got it!</button> <br>
 <button data-i18n="inst-nvm" class="button" onclick="location.href='index.html';" style="background-color: #f44336;">Wait, nevermind!</button> <br>
 
-<!-- Default Statcounter code for LeftValues http://leftvalues.github.io -->
+<!-- Privacy respecting Statcounter code for LeftValues http://leftvalues.github.io -->
 <script type="text/javascript">
 var sc_project=12079783; 
 var sc_invisible=1; 
 var sc_security="fa5443fa"; 
-var sc_https=1; 
+var sc_https=1;
+if(navigator.doNotTrack != 1) {
+var statcounterscript=document.createElement('script');
+statcounterscript.setAttribute("type","text/javascript");
+statcounterscript.setAttribute("src", "https://www.statcounter.com/counter/counter.js");
+document.getElementsByTagName("body")[0].appendChild(statcounterscript);
+}
 </script>
-<script type="text/javascript"
-src="https://www.statcounter.com/counter/counter.js" async></script>
-<noscript><div class="statcounter"><a title="Web Analytics"
-href="https://statcounter.com/" target="_blank"><img class="statcounter"
-src="https://c.statcounter.com/12079783/0/fa5443fa/1/" alt="Web
-Analytics"></a></div></noscript>
 <!-- End of Statcounter Code -->
 <!-- JavaScript for the test itself -->
 <script type="application/javascript"src="i18n.js"></script>

--- a/quiz.html
+++ b/quiz.html
@@ -24,19 +24,19 @@
 <button data-i18n="quiz-back" class="small_button_off" id="back_button_off">Back</button>
 <br>
 
-<!-- Default Statcounter code for LeftValues http://leftvalues.github.io -->
+<!-- Privacy respecting Statcounter code for LeftValues http://leftvalues.github.io -->
 <script type="text/javascript">
 var sc_project=12079783; 
 var sc_invisible=1; 
 var sc_security="fa5443fa"; 
-var sc_https=1; 
+var sc_https=1;
+if(navigator.doNotTrack != 1) {
+var statcounterscript=document.createElement('script');
+statcounterscript.setAttribute("type","text/javascript");
+statcounterscript.setAttribute("src", "https://www.statcounter.com/counter/counter.js");
+document.getElementsByTagName("body")[0].appendChild(statcounterscript);
+}
 </script>
-<script type="text/javascript"
-src="https://www.statcounter.com/counter/counter.js" async></script>
-<noscript><div class="statcounter"><a title="Web Analytics"
-href="https://statcounter.com/" target="_blank"><img class="statcounter"
-src="https://c.statcounter.com/12079783/0/fa5443fa/1/" alt="Web
-Analytics"></a></div></noscript>
 <!-- End of Statcounter Code -->
 
 <!-- JavaScript for the test itself -->

--- a/results.html
+++ b/results.html
@@ -80,19 +80,19 @@
 <hr/>
 <canvas id="banner" width=800 height=1000 style="font-family:Montserrat"></canvas>
 <button data-i18n="result-back" class="button" onclick="location.href='index.html';" style="background-color: #2196f3;">Back</button> <br>
-<!-- Default Statcounter code for LeftValues http://leftvalues.github.io -->
+<!-- Privacy respecting Statcounter code for LeftValues http://leftvalues.github.io -->
 <script type="text/javascript">
 var sc_project=12079783; 
 var sc_invisible=1; 
 var sc_security="fa5443fa"; 
-var sc_https=1; 
+var sc_https=1;
+if(navigator.doNotTrack != 1) {
+var statcounterscript=document.createElement('script');
+statcounterscript.setAttribute("type","text/javascript");
+statcounterscript.setAttribute("src", "https://www.statcounter.com/counter/counter.js");
+document.getElementsByTagName("body")[0].appendChild(statcounterscript);
+}
 </script>
-<script type="text/javascript"
-src="https://www.statcounter.com/counter/counter.js" async></script>
-<noscript><div class="statcounter"><a title="Web Analytics"
-href="https://statcounter.com/" target="_blank"><img class="statcounter"
-src="https://c.statcounter.com/12079783/0/fa5443fa/1/" alt="Web
-Analytics"></a></div></noscript>
 <!-- End of Statcounter Code -->
 <!-- JavaScript for the test itself -->
 <script type="application/javascript"src="i18n.js"></script>


### PR DESCRIPTION
I think this would be the correct behaviour. It probably won't have a huge effect on the stats as most people don't have DNT activated. But those who do will probably appreciate this change. I took the freedom to remove the <noscript> Tag as the script won't work for people without JS anyways. I would appreciate thinking about removing Google-Fonts too. Many people probably won't like to share their data with Google unnecessarily. Referencing #14 