### PR TITLE
add polish

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -126,7 +126,8 @@ async function loadTranslation () { // eslint-disable-line no-unused-vars
     getl10n('ko'),
     getl10n('pt'),
     getl10n('ru'),
-    getl10n('sh')
+    getl10n('sh'),
+    getl10n('pl')
   ]).then(() => {
     console.log(i18n)
 


### PR DESCRIPTION
while language files get manually added to the `lang/` directory, we still need to manually add this line to load them.
Thanks to @sech1p polish now reached 100% translation, so we should finally add it to the website.

![polish translation status](https://user-images.githubusercontent.com/5024958/83361941-97293d80-a38d-11ea-8acc-adf38db05876.png)


Not sure when we should start adding languages. any line that isn't translated just gets the english fallback so we could start adding languages a lot earlier.
Also we should probably sort the alphabetically or something, the current order is pretty confusing