### PR TITLE
Enable Ukrainian translation

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -15,7 +15,7 @@ function setBodyClassUserLang (userLang) {
 }
 
 const langElements = document.querySelectorAll('[data-i18n]')
-const userLang = getCookie('lang') || navigator.language || navigator.userLanguage
+const userLang = (getCookie('lang') || navigator.language || navigator.userLanguage).replace(/-.*/, "")
 setBodyClassUserLang(userLang)
 
 const langPicker = document.getElementById('langPicker')
@@ -121,6 +121,7 @@ async function loadTranslation () { // eslint-disable-line no-unused-vars
     getl10n('en'),
     getl10n('es'),
     getl10n('de'),
+    getl10n('uk'),
     getl10n('cn'),
     getl10n('ko'),
     getl10n('pt'),


### PR DESCRIPTION
The lines were ready in commit 84a55df. The change to userLang is for the languages of people whose locales have dashes to be correctly enabled. For example, navigator.language is usually "uk-UA" here while the translation key is just "uk".